### PR TITLE
Sprint5 task4 admin add number of available kudos

### DIFF
--- a/app/controllers/AdminUsers/employees_controller.rb
+++ b/app/controllers/AdminUsers/employees_controller.rb
@@ -25,6 +25,30 @@ module AdminUsers
       redirect_to admin_users_employees_path, notice: 'Employee was successfully destroyed.'
     end
 
+    def edit_number_of_available_kudos_for_all
+      render :edit_number_of_available_kudos_for_all, locals: { employees: Employee.all }
+    end
+
+    def update_number_of_available_kudos_for_all
+      if added_kudos_params.positive? && added_kudos_params <= 20
+        begin
+          ActiveRecord::Base.transaction do
+            Employee.all.each do |employee|
+              employee.increment(:number_of_available_kudos, added_kudos_params).save!
+            end
+          end
+        rescue StandardError
+          redirect_to dashboard_admin_users_pages_path, alert: 'Unfortunately something went wrong :('
+        else
+          redirect_to admin_users_employees_path,
+                      notice: "Each employee received #{added_kudos_params} additional kudos for use."
+        end
+      else
+        redirect_to dashboard_admin_users_pages_path,
+                    alert: 'Given number is not valid, please enter a number between 1 to 20.'
+      end
+    end
+
     private
 
     def employee
@@ -33,6 +57,10 @@ module AdminUsers
 
     def employee_params
       params.require(:employee).permit(:email, :password, :number_of_available_kudos)
+    end
+
+    def added_kudos_params
+      params[:number_of_added_kudos].to_i
     end
   end
 end

--- a/app/controllers/AdminUsers/employees_controller.rb
+++ b/app/controllers/AdminUsers/employees_controller.rb
@@ -25,11 +25,10 @@ module AdminUsers
       redirect_to admin_users_employees_path, notice: 'Employee was successfully destroyed.'
     end
 
-    def edit_number_of_available_kudos_for_all
-      render :edit_number_of_available_kudos_for_all, locals: { employees: Employee.all }
-    end
+    def edit_number_of_available_kudos_for_all; end
 
-    def update_number_of_available_kudos_for_all
+    def add_available_kudos_for_all
+      added_kudos_params = params[:number_of_added_kudos].to_i
       if added_kudos_params.positive? && added_kudos_params <= 20
         begin
           ActiveRecord::Base.transaction do
@@ -57,10 +56,6 @@ module AdminUsers
 
     def employee_params
       params.require(:employee).permit(:email, :password, :number_of_available_kudos)
-    end
-
-    def added_kudos_params
-      params[:number_of_added_kudos].to_i
     end
   end
 end

--- a/app/controllers/display_orders_controller.rb
+++ b/app/controllers/display_orders_controller.rb
@@ -2,7 +2,7 @@ class DisplayOrdersController < ApplicationController
   before_action :authenticate_employee!
 
   def index
-    if params[:filter]
+    if %w[delivered not_delivered].include?(params[:filter])
       render :index, locals: { orders: Order.where(employee: current_employee)
                                             .filter_by_status(params[:filter])
                                             .paginate(page: params[:page], per_page: 5)

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -8,6 +8,6 @@ class Employee < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  validates :number_of_available_kudos, numericality: { less_than_or_equal_to: 10, greater_than_or_equal_to: 0 }
+  validates :number_of_available_kudos, numericality: { greater_than_or_equal_to: 0 }
   validates :earned_points, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/views/admin_users/employees/edit_number_of_available_kudos_for_all.html.erb
+++ b/app/views/admin_users/employees/edit_number_of_available_kudos_for_all.html.erb
@@ -1,0 +1,19 @@
+<div class="card mt-4">
+  <div class="card-header">
+    <h2>Increase the number of kudos available for each employee by a number from 1 to 20</h2>
+  </div>
+
+  <div class="card-body">
+    <%= form_with url: "update_number_of_available_kudos_for_all", method: :patch do |form| %>
+
+      <div class="field form-group">
+        <%= form.number_field :number_of_added_kudos, in: 1..20, autofocus: true, class: "form-control", placeholder: "Number of kudos" %>
+      </div>
+      
+      <div class="actions mt-3">
+        <%= form.submit "Add Kudos", data: { confirm: "Are you sure?" }, class: "btn btn-dark" %>
+      </div>
+    <% end %>
+    <%= link_to "Back to Admin Dashboard", dashboard_admin_users_pages_path, class:"btn btn-outline-secondary mt-3" %>
+  </div>
+</div>

--- a/app/views/admin_users/employees/edit_number_of_available_kudos_for_all.html.erb
+++ b/app/views/admin_users/employees/edit_number_of_available_kudos_for_all.html.erb
@@ -4,7 +4,7 @@
   </div>
 
   <div class="card-body">
-    <%= form_with url: "update_number_of_available_kudos_for_all", method: :patch do |form| %>
+    <%= form_with url: "add_available_kudos_for_all", method: :patch do |form| %>
 
       <div class="field form-group">
         <%= form.number_field :number_of_added_kudos, in: 1..20, autofocus: true, class: "form-control", placeholder: "Number of kudos" %>

--- a/app/views/admin_users/pages/dashboard.html.erb
+++ b/app/views/admin_users/pages/dashboard.html.erb
@@ -12,6 +12,11 @@
         </div>
         <div class="col">
           <div class="card bg-dark">
+              <%= link_to 'Add Kudos', edit_number_of_available_kudos_for_all_admin_users_employees_path, class:'btn btn-outline-light btn-lg' %>
+          </div>
+        </div>
+        <div class="col">
+          <div class="card bg-dark">
               <%= link_to 'Manage Employees', admin_users_employees_path, class:'btn btn-outline-light btn-lg' %>
           </div>
         </div>

--- a/app/views/layouts/_alerts.html.erb
+++ b/app/views/layouts/_alerts.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <% if alert %>
-  <div class="alert alert-warning alert-dismissible fade show" role="alert">
+  <div class="alert alert-danger alert-dismissible fade show" role="alert">
     <%= alert %>
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
     resources :employees, only: %i[index edit update destroy] do
       collection do
         resources :orders, only: %i[index update]
+        get 'edit_number_of_available_kudos_for_all'
+        patch 'update_number_of_available_kudos_for_all'
       end
     end
     resources :company_values, except: %i[show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
       collection do
         resources :orders, only: %i[index update]
         get 'edit_number_of_available_kudos_for_all'
-        patch 'update_number_of_available_kudos_for_all'
+        patch 'add_available_kudos_for_all'
       end
     end
     resources :company_values, except: %i[show]

--- a/spec/system/admin_employees_spec.rb
+++ b/spec/system/admin_employees_spec.rb
@@ -91,4 +91,26 @@ RSpec.describe 'Modifying employees', type: :system do
       expect(Employee.count).to eq 0
     end
   end
+
+  context 'when incrementing number of available kudos for all employees' do
+    let!(:employee1) { create(:employee, number_of_available_kudos: first_number_of_kudos) }
+
+    it 'increments number of available kudos for all employees' do
+      expect(employee.number_of_available_kudos).to eq first_number_of_kudos
+      expect(employee1.number_of_available_kudos).to eq first_number_of_kudos
+
+      visit '/admin/pages/dashboard'
+      click_link 'Add Kudos'
+
+      fill_in 'Number of kudos', with: second_number_of_kudos
+      click_button 'Add Kudos'
+
+      expect(page).to have_content "Each employee received #{second_number_of_kudos} additional kudos for use."
+
+      employee.reload
+      employee1.reload
+      expect(employee.number_of_available_kudos).to eq(first_number_of_kudos + second_number_of_kudos)
+      expect(employee1.number_of_available_kudos).to eq(first_number_of_kudos + second_number_of_kudos)
+    end
+  end
 end

--- a/spec/system/admin_employees_spec.rb
+++ b/spec/system/admin_employees_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 require 'factory_bot_rails'
 
 RSpec.describe 'Modifying employees', type: :system do
+  let(:first_number_of_kudos) { 7 }
+  let(:second_number_of_kudos) { 10 }
   let(:admin_user) { create(:admin_user) }
-  let!(:employee) { create(:employee) }
+  let!(:employee) { create(:employee, number_of_available_kudos: first_number_of_kudos) }
 
   before do
     driven_by(:rack_test)
@@ -36,7 +38,7 @@ RSpec.describe 'Modifying employees', type: :system do
 
       fill_in 'Email', with: 'changed@mail.com'
       fill_in 'Password', with: 'password1'
-      fill_in 'Number of kudos', with: 7
+      fill_in 'Number of kudos', with: second_number_of_kudos
 
       click_button 'Update'
 
@@ -45,7 +47,7 @@ RSpec.describe 'Modifying employees', type: :system do
       expect(page).to have_content 'Employee was successfully updated.'
       expect(employee.email).to eq 'changed@mail.com'
       expect(employee.valid_password?('password1')).to be true
-      expect(employee.number_of_available_kudos).to eq 7
+      expect(employee.number_of_available_kudos).to eq second_number_of_kudos
     end
 
     it 'enables to update without changing password' do
@@ -53,7 +55,7 @@ RSpec.describe 'Modifying employees', type: :system do
       click_link 'Edit'
 
       fill_in 'Email', with: 'changed@mail.com'
-      fill_in 'Number of kudos', with: 7
+      fill_in 'Number of kudos', with: second_number_of_kudos
 
       click_button 'Update'
 
@@ -61,7 +63,7 @@ RSpec.describe 'Modifying employees', type: :system do
 
       expect(page).to have_content 'Employee was successfully updated.'
       expect(employee.email).to eq 'changed@mail.com'
-      expect(employee.number_of_available_kudos).to eq 7
+      expect(employee.number_of_available_kudos).to eq second_number_of_kudos
     end
 
     it 'checks validation' do


### PR DESCRIPTION
Hey! The code which is below was implemented in order to meet the acceptance criterias of the last task in sprint no. 5.

AC in this task:
-- There's an "Add Kudos" link in the admin panel's navigation which opens a form for adding kudos
-- "Add Kudos" form has one numerical input for the number of kudos
-- The number of kudos in the "Add Kudos" form has to be between 1 and 20
-- Submitting the "Add Kudos" form adds the same number of kudos to the `number_of_available_kudos` field of each employee
-- After successfully submitting the "Add Kudos" form, admin sees a flash message with a confirmation
-- There's a system spec for admin adding kudos to multiple employees


https://user-images.githubusercontent.com/96024046/178150501-645fbcf1-9e57-4b57-b067-0b5786a4a1c4.mov

