### PR TITLE
Refactor service objects

### DIFF
--- a/app/controllers/admin_users/online_codes_controller.rb
+++ b/app/controllers/admin_users/online_codes_controller.rb
@@ -45,7 +45,7 @@ module AdminUsers
     def import_from_csv
       online_codes = OnlineCodesImportService.new(params)
 
-      if online_codes.import
+      if online_codes.call
         redirect_to admin_users_online_codes_path, notice: 'Online codes were successfully imported.'
       else
         redirect_to admin_users_online_codes_path, alert: online_codes.errors.join('; ')

--- a/app/controllers/admin_users/rewards_controller.rb
+++ b/app/controllers/admin_users/rewards_controller.rb
@@ -43,19 +43,12 @@ module AdminUsers
     end
 
     def import_from_csv
-      if params[:reward][:file].nil?
-        redirect_to new_import_from_csv_admin_users_rewards_path, alert: 'Please select a file'
-      elsif File.extname(params[:reward][:file]) != '.csv'
-        redirect_to new_import_from_csv_admin_users_rewards_path, alert: 'Only .csv files are allowed.'
+      rewards_import_service = RewardsImportService.new(params)
+
+      if rewards_import_service.call
+        redirect_to admin_users_rewards_path, notice: 'Rewards were successfully imported.'
       else
-        begin
-          RewardsImportService.import(params[:reward][:file])
-        rescue ActiveRecord::RecordInvalid => e
-          redirect_to new_import_from_csv_admin_users_rewards_path,
-                      alert: "Errors in CSV file: <br> #{e.message}."
-        else
-          redirect_to admin_users_rewards_path, notice: 'Rewards were successfully imported.'
-        end
+        redirect_to admin_users_rewards_path, alert: rewards_import_service.errors.join('; ')
       end
     end
 

--- a/app/models/reward.rb
+++ b/app/models/reward.rb
@@ -5,6 +5,7 @@ class Reward < ApplicationRecord
   belongs_to :category, optional: true
 
   validates :title, :description, :price, :delivery_method, presence: true
+  validates :title, uniqueness: { case_sensitive: false }
   validates :price, numericality: { greater_than_or_equal_to: 1 }
 
   enum delivery_method: { online: 0, post_delivery: 1 }, _prefix: true

--- a/app/services/online_codes_import_service.rb
+++ b/app/services/online_codes_import_service.rb
@@ -8,7 +8,7 @@ class OnlineCodesImportService
     @errors = []
   end
 
-  def import
+  def call
     if @file.nil?
       @errors << 'file cannot be empty'
       false

--- a/app/services/rewards_import_service.rb
+++ b/app/services/rewards_import_service.rb
@@ -1,20 +1,35 @@
 require 'csv'
 
 class RewardsImportService
-  def initialize(data)
-    @data = data
+  attr_reader :errors
+
+  def initialize(params)
+    @file = params[:file]
+    @errors = []
   end
 
-  def self.import(file)
-    ActiveRecord::Base.transaction do
-      CSV.foreach(file.path, headers: true) do |row|
-        reward = Reward.find_or_initialize_by(title: row['Title'])
-        reward.description = row['Description']
-        reward.price = row['Price']
-        reward.delivery_method = row['DeliveryMethod']
-        reward.category = Category.find_or_create_by!(title: row['Category'])
-        reward.save!
+  def call
+    if @file.nil?
+      @errors << 'file cannot be empty'
+      false
+    elsif File.extname(@file) != '.csv'
+      @errors << 'must be a .csv file'
+      false
+    else
+      ActiveRecord::Base.transaction do
+        CSV.foreach(@file.path, headers: true) do |row|
+          reward = Reward.find_or_initialize_by(title: row['Title'])
+          reward.description = row['Description']
+          reward.price = row['Price']
+          reward.delivery_method = row['DeliveryMethod']
+          reward.category = Category.find_or_create_by!(title: row['Category'])
+          reward.save!
+        end
       end
+      true
     end
+  rescue ActiveRecord::RecordInvalid => e
+    @errors << e.message
+    false
   end
 end

--- a/app/views/admin_users/rewards/new_import_from_csv.html.erb
+++ b/app/views/admin_users/rewards/new_import_from_csv.html.erb
@@ -4,7 +4,7 @@
       <h2>Import rewards from CSV file</h2>
     </div>
     <div class="card-body">
-      <%= form_for reward, url: import_from_csv_admin_users_rewards_path do |f| %>
+      <%= form_with url: import_from_csv_admin_users_rewards_path do |f| %>
         <div class="form-group">
           <%= f.file_field :file, class: 'form-control-file', required: true, accept: 'csv' %>
         </div>

--- a/spec/factories/reward.rb
+++ b/spec/factories/reward.rb
@@ -2,7 +2,7 @@ require 'faker'
 
 FactoryBot.define do
   factory :reward do
-    title { Faker::Book.unique.title }
+    title { Faker::Creature::Animal.unique.name }
     description { Faker::Hipster.unique.paragraph_by_chars(characters: 40) }
     price { 1 }
     delivery_method { 'online' }

--- a/spec/services/online_codes_import_service_spec.rb
+++ b/spec/services/online_codes_import_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe OnlineCodesImportService do
       service = described_class.new(params)
 
       result = nil
-      expect { result = service.import }.to change(OnlineCode, :count).by(2)
+      expect { result = service.call }.to change(OnlineCode, :count).by(2)
       expect(result).to be true
     end
 
@@ -18,7 +18,7 @@ RSpec.describe OnlineCodesImportService do
       params = { file: fixture_file_upload('./spec/fixtures/online_codes/invalid_no_code_online_codes_import.csv') }
       service = described_class.new(params)
 
-      expect(service.import).to be false
+      expect(service.call).to be false
       expect(service.errors.to_s).to include "Code can't be blank"
     end
 
@@ -26,7 +26,7 @@ RSpec.describe OnlineCodesImportService do
       params = { file: fixture_file_upload('./spec/fixtures/online_codes/invalid_no_reward_online_codes_import.csv') }
       service = described_class.new(params)
 
-      expect(service.import).to be false
+      expect(service.call).to be false
       expect(service.errors.to_s).to include "Couldn't find Reward"
     end
   end

--- a/spec/system/admin_rewards_from_csv_spec.rb
+++ b/spec/system/admin_rewards_from_csv_spec.rb
@@ -90,9 +90,9 @@ RSpec.describe 'Import rewards from a CSV', type: :system do
       attach_file(File.absolute_path('./spec/fixtures/rewards/invalid_rewards_import.csv'))
       click_button 'Import Rewards'
 
-      expect(page).to have_content "Errors in CSV file: Validation failed: Title can't be blank, " \
+      expect(page).to have_content "Validation failed: Title can't be blank, " \
                                    "Description can't be blank, Delivery method can't be blank, " \
-                                   'Price is not a number.'
+                                   'Price is not a number'
       expect(Reward.count).to eq 0
     end
   end


### PR DESCRIPTION
Present pull request focuses on making services objects look more consistent to each other.

I decided to introduce to this app general principle according to which every service object should contain only one `call` public method. 

Commented pull request repairs also one test problem with factoring rewards -> faker gem sometimes generated reward title with comma what was a problem for csv table. 