### PR TITLE
refactor: change name of delivery method from post_delivery to post

### DIFF
--- a/app/models/reward.rb
+++ b/app/models/reward.rb
@@ -8,7 +8,7 @@ class Reward < ApplicationRecord
   validates :title, uniqueness: { case_sensitive: false }
   validates :price, numericality: { greater_than_or_equal_to: 1 }
 
-  enum delivery_method: { online: 0, post_delivery: 1 }, _prefix: true
+  enum delivery_method: { online: 0, post: 1 }, _prefix: true
   scope :by_category, ->(category) { where(category: category) if Category.exists?(id: category) }
 
   has_one_attached :photo
@@ -19,7 +19,7 @@ class Reward < ApplicationRecord
   end
 
   def available_for_purchase?
-    delivery_method_post_delivery? || number_of_available_items.positive?
+    delivery_method_post? || number_of_available_items.positive?
   end
 
   private

--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -15,7 +15,7 @@ class CreateOrderService
     return false unless reward_for_sale?
 
     ActiveRecord::Base.transaction do
-      create_or_update_address if @reward.delivery_method_post_delivery?
+      create_or_update_address if @reward.delivery_method_post?
       assign_online_code if @reward.delivery_method_online?
       @order.reward_snapshot = @reward
       @order.save!

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -34,7 +34,7 @@
       </tbody>      
     </table>
 
-    <%= render 'delivery_address_form' if @reward.delivery_method_post_delivery? %>
+    <%= render 'delivery_address_form' if @reward.delivery_method_post? %>
 
     <%= form.hidden_field :reward_id, value: @reward.id %>
     <%= form.hidden_field :employee_id, value: current_employee.id %>

--- a/spec/fixtures/rewards/new_and_existing_rewards_import.csv
+++ b/spec/fixtures/rewards/new_and_existing_rewards_import.csv
@@ -1,3 +1,3 @@
 Title,Description,Price,DeliveryMethod,Category
 RewardTitle,ChangedRewardDescription,4,online,ChangedCategory
-RewardTitle3,RewardDescription3,7,post_delivery,Category3
+RewardTitle3,RewardDescription3,7,post,Category3

--- a/spec/fixtures/rewards/only_new_rewards_import.csv
+++ b/spec/fixtures/rewards/only_new_rewards_import.csv
@@ -1,3 +1,3 @@
 Title,Description,Price,DeliveryMethod,Category
-RewardTitle,RewardDescription,3,post_delivery,Category1
+RewardTitle,RewardDescription,3,post,Category1
 RewardTitle2,RewardDescription2,4,online,Category2

--- a/spec/services/create_order_service_spec.rb
+++ b/spec/services/create_order_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe CreateOrderService do
   context 'when buying a reward with post delivery method' do
     it 'returns true, adds new order and adress to database when all params are properly set and does not send email' do
       employee = create(:employee, earned_points: 1)
-      reward_with_post_delivery = create(:reward, delivery_method: 'post_delivery')
+      reward_with_post_delivery = create(:reward, delivery_method: 'post')
       order_params = { employee_id: employee.id, reward_id: reward_with_post_delivery.id }
       address_params = { street: '221B Baker Street', postcode: 'NW1 6XE', city: 'London' }
       service = described_class.new(order_params.merge(address_params))
@@ -60,7 +60,7 @@ RSpec.describe CreateOrderService do
 
     it "updates employee's address when address already exists" do
       employee = create(:employee, earned_points: 1)
-      reward_with_post_delivery = create(:reward, delivery_method: 'post_delivery')
+      reward_with_post_delivery = create(:reward, delivery_method: 'post')
       create(:address, employee: employee)
       order_params = { employee_id: employee.id, reward_id: reward_with_post_delivery.id }
       address_params = { street: '221B Baker Street', postcode: 'NW1 6XE', city: 'London' }
@@ -78,7 +78,7 @@ RSpec.describe CreateOrderService do
 
     it 'returns false while address data are not proper' do
       employee = create(:employee, earned_points: 1)
-      reward_with_post_delivery = create(:reward, delivery_method: 'post_delivery')
+      reward_with_post_delivery = create(:reward, delivery_method: 'post')
       order_params = { employee_id: employee.id, reward_id: reward_with_post_delivery.id }
       address_params = {}
       service = described_class.new(order_params.merge(address_params))

--- a/spec/system/admin_rewards_from_csv_spec.rb
+++ b/spec/system/admin_rewards_from_csv_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Import rewards from a CSV', type: :system do
       expect(Reward.first.title).to eq 'RewardTitle'
       expect(Reward.first.description).to eq 'RewardDescription'
       expect(Reward.first.price).to eq 3
-      expect(Reward.first.delivery_method).to eq 'post_delivery'
+      expect(Reward.first.delivery_method).to eq 'post'
       expect(Reward.first.category.title).to eq 'Category1'
       expect(Reward.last.title).to eq 'RewardTitle2'
       expect(Reward.last.description).to eq 'RewardDescription2'
@@ -34,7 +34,7 @@ RSpec.describe 'Import rewards from a CSV', type: :system do
       expect(page).to have_content 'RewardTitle'
       expect(page).to have_content 'RewardDescription'
       expect(page).to have_content '3'
-      expect(page).to have_content 'Post Delivery'
+      expect(page).to have_content 'Post'
       expect(page).to have_content 'Category1'
       expect(page).to have_content 'RewardTitle2'
       expect(page).to have_content 'RewardDescription2'
@@ -67,7 +67,7 @@ RSpec.describe 'Import rewards from a CSV', type: :system do
       expect(Reward.last.title).to eq 'RewardTitle3'
       expect(Reward.last.description).to eq 'RewardDescription3'
       expect(Reward.last.price).to eq 7
-      expect(Reward.last.delivery_method).to eq 'post_delivery'
+      expect(Reward.last.delivery_method).to eq 'post'
       expect(Reward.last.category.title).to eq 'Category3'
       expect(page).to have_content 'RewardTitle'
       expect(page).to have_content 'ChangedRewardDescription'
@@ -77,7 +77,7 @@ RSpec.describe 'Import rewards from a CSV', type: :system do
       expect(page).to have_content 'RewardTitle3'
       expect(page).to have_content 'RewardDescription2'
       expect(page).to have_content '7'
-      expect(page).to have_content 'Post Delivery'
+      expect(page).to have_content 'Post'
       expect(page).to have_content 'Category3'
     end
 


### PR DESCRIPTION
The current pull request changes `post_delivery` method name to `post` for better consistency.