### PR TITLE
Sprint8 task3 add pick up delivery

### DIFF
--- a/app/controllers/admin_users/orders_controller.rb
+++ b/app/controllers/admin_users/orders_controller.rb
@@ -11,7 +11,7 @@ module AdminUsers
         redirect_back fallback_location: admin_users_employees_path,
                       notice: 'The order has already been delivered.'
       elsif order.update(status: :delivered)
-        EmployeeMailer.post_delivery_confirmation_email(order).deliver_now
+        send_confirmation_email_to_employee
         redirect_back fallback_location: admin_users_employees_path,
                       notice: 'The order has been delivered successfully!'
       else
@@ -36,6 +36,14 @@ module AdminUsers
 
     def order
       @order ||= Order.find(params[:id])
+    end
+
+    def send_confirmation_email_to_employee
+      if order.reward_snapshot.delivery_method_post?
+        EmployeeMailer.post_delivery_confirmation_email(order).deliver_now
+      elsif order.reward_snapshot.delivery_method_pick_up?
+        EmployeeMailer.pick_up_delivery_confirmation_email(order).deliver_now
+      end
     end
   end
 end

--- a/app/mailers/employee_mailer.rb
+++ b/app/mailers/employee_mailer.rb
@@ -11,4 +11,16 @@ class EmployeeMailer < ApplicationMailer
     @reward = order.reward_snapshot
     mail(to: @employee.email, subject: 'Reward has been delivered!')
   end
+
+  def pick_up_delivery_instructions_email(order)
+    @employee = order.employee
+    @reward = order.reward_snapshot
+    mail(to: @employee.email, subject: 'Pick-up delivery instructions')
+  end
+
+  def pick_up_delivery_confirmation_email(order)
+    @employee = order.employee
+    @reward = order.reward_snapshot
+    mail(to: @employee.email, subject: 'Reward has been received!')
+  end
 end

--- a/app/models/reward.rb
+++ b/app/models/reward.rb
@@ -8,7 +8,7 @@ class Reward < ApplicationRecord
   validates :title, uniqueness: { case_sensitive: false }
   validates :price, numericality: { greater_than_or_equal_to: 1 }
 
-  enum delivery_method: { online: 0, post: 1 }, _prefix: true
+  enum delivery_method: { online: 0, post: 1, pick_up: 2 }, _prefix: true
   scope :by_category, ->(category) { where(category: category) if Category.exists?(id: category) }
 
   has_one_attached :photo
@@ -19,7 +19,7 @@ class Reward < ApplicationRecord
   end
 
   def available_for_purchase?
-    delivery_method_post? || number_of_available_items.positive?
+    delivery_method_post? || delivery_method_pick_up? || number_of_available_items.positive?
   end
 
   private

--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -1,5 +1,5 @@
 class CreateOrderService
-  attr_reader :errors
+  attr_reader :errors, :order
 
   def initialize(params)
     @reward = Reward.find_by(id: params[:reward_id])
@@ -22,7 +22,7 @@ class CreateOrderService
       @employee.decrement(:earned_points, @reward.price).save!
       @order.status_delivered! if @reward.delivery_method_online?
     end
-    send_email_to_employee if @reward.delivery_method_online?
+    send_email_to_employee unless @reward.delivery_method_post?
     true
   rescue ActiveRecord::StatementInvalid, ActiveRecord::RecordInvalid => e
     @errors << e.message
@@ -56,6 +56,10 @@ class CreateOrderService
   end
 
   def send_email_to_employee
-    EmployeeMailer.online_delivery_confirmation_email(@order).deliver_now
+    if @reward.delivery_method_online?
+      EmployeeMailer.online_delivery_confirmation_email(@order).deliver_now
+    elsif @reward.delivery_method_pick_up?
+      EmployeeMailer.pick_up_delivery_instructions_email(@order).deliver_now
+    end
   end
 end

--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -1,5 +1,5 @@
 class CreateOrderService
-  attr_reader :errors, :order
+  attr_reader :errors
 
   def initialize(params)
     @reward = Reward.find_by(id: params[:reward_id])

--- a/app/views/employee_mailer/pick_up_delivery_confirmation_email.html.erb
+++ b/app/views/employee_mailer/pick_up_delivery_confirmation_email.html.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+  </head>
+  <body>
+    <h1>Thank you for purchasing a reward: <%= @reward.title %> !</h1>
+    <p>We kindly inform about picking up above reward. It's happened today!</p>
+    <p>AppForEmployees</p>
+  </body>
+</html>

--- a/app/views/employee_mailer/pick_up_delivery_confirmation_email.text.erb
+++ b/app/views/employee_mailer/pick_up_delivery_confirmation_email.text.erb
@@ -1,0 +1,6 @@
+Thank you for purchasing a reward: <%= @reward.title %> !
+===============================================
+
+We kindly inform about picking up above reward. It's happened today!
+
+AppForEmployees

--- a/app/views/employee_mailer/pick_up_delivery_instructions_email.html.erb
+++ b/app/views/employee_mailer/pick_up_delivery_instructions_email.html.erb
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+  </head>
+  <body>
+    <h1>Thank you for purchasing a reward: <%= @reward.title %> !</h1>
+    <p>We kindly inform about receiving order on above reward.</p>
+    <p>Below we leave instructions related to picking up ordered reward.</p>
+    <p>You can pick up your reward from <%= (Time.now + (60*60*24*3)).strftime('%e %B %Y') %></p>
+    <p>Pickup address: 221B Baker Street, NW1 6XE London</p>
+    <p>AppForEmployees</p>
+  </body>
+</html>

--- a/app/views/employee_mailer/pick_up_delivery_instructions_email.html.erb
+++ b/app/views/employee_mailer/pick_up_delivery_instructions_email.html.erb
@@ -7,7 +7,7 @@
     <h1>Thank you for purchasing a reward: <%= @reward.title %> !</h1>
     <p>We kindly inform about receiving order on above reward.</p>
     <p>Below we leave instructions related to picking up ordered reward.</p>
-    <p>You can pick up your reward from <%= (Time.now + (60*60*24*3)).strftime('%e %B %Y') %></p>
+    <p>You can pick up your reward from <%= (Time.current + 3.days).strftime('%e %B %Y') %></p>
     <p>Pickup address: 221B Baker Street, NW1 6XE London</p>
     <p>AppForEmployees</p>
   </body>

--- a/app/views/employee_mailer/pick_up_delivery_instructions_email.text.erb
+++ b/app/views/employee_mailer/pick_up_delivery_instructions_email.text.erb
@@ -1,0 +1,11 @@
+Thank you for purchasing a reward: <%= @reward.title %> !
+===============================================
+
+We kindly inform about receiving order on above reward.
+
+Below we leave instructions related to picking up ordered reward.
+
+You can pick up your reward from <%= (Time.now + (60*60*24*3)).strftime('%e %B %Y') %>
+Pickup address: 221B Baker Street, NW1 6XE London
+
+AppForEmployees

--- a/app/views/employee_mailer/pick_up_delivery_instructions_email.text.erb
+++ b/app/views/employee_mailer/pick_up_delivery_instructions_email.text.erb
@@ -5,7 +5,7 @@ We kindly inform about receiving order on above reward.
 
 Below we leave instructions related to picking up ordered reward.
 
-You can pick up your reward from <%= (Time.now + (60*60*24*3)).strftime('%e %B %Y') %>
+You can pick up your reward from <%= (Time.current + 3.days).strftime('%e %B %Y') %>
 Pickup address: 221B Baker Street, NW1 6XE London
 
 AppForEmployees

--- a/spec/mailers/employee_mailer_spec.rb
+++ b/spec/mailers/employee_mailer_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe EmployeeMailer, type: :mailer do
     end
 
     context 'when post delivery' do
-      let(:order) { create(:order) }
+      let(:reward) { create(:reward, delivery_method: 'post') }
+      let(:order) { create(:order, reward: reward) }
       let(:email) { described_class.post_delivery_confirmation_email(order) }
 
       it 'renders the headers' do
@@ -32,6 +33,41 @@ RSpec.describe EmployeeMailer, type: :mailer do
       end
 
       it 'renders the body' do
+        expect(email.text_part.body).to have_content order.reward.title
+        expect(email.html_part.body).to have_content order.reward.title
+      end
+    end
+
+    context 'when pick up delivery' do
+      let(:reward) { create(:reward, delivery_method: 'pick_up') }
+      let(:order) { create(:order, reward: reward) }
+
+      it 'renders email headers with instructions' do
+        email = described_class.pick_up_delivery_instructions_email(order)
+
+        expect(email.subject).to eq 'Pick-up delivery instructions'
+        expect(email.to).to eq [order.employee.email]
+        expect(email.from).to eq [Rails.application.credentials.dig(:sendgrid, :sender_email)]
+      end
+
+      it 'renders email body with instructions' do
+        email = described_class.pick_up_delivery_instructions_email(order)
+
+        expect(email.text_part.body).to have_content order.reward.title
+        expect(email.html_part.body).to have_content order.reward.title
+      end
+
+      it 'renders email headers with confirmation' do
+        email = described_class.pick_up_delivery_confirmation_email(order)
+
+        expect(email.subject).to eq 'Reward has been received!'
+        expect(email.to).to eq [order.employee.email]
+        expect(email.from).to eq [Rails.application.credentials.dig(:sendgrid, :sender_email)]
+      end
+
+      it 'renders email body with confirmation' do
+        email = described_class.pick_up_delivery_confirmation_email(order)
+
         expect(email.text_part.body).to have_content order.reward.title
         expect(email.html_part.body).to have_content order.reward.title
       end

--- a/spec/mailers/previews/employee_mailer_preview.rb
+++ b/spec/mailers/previews/employee_mailer_preview.rb
@@ -9,8 +9,23 @@ class EmployeeMailerPreview < ActionMailer::Preview
   end
 
   def post_delivery_confirmation_email
-    order = FactoryBot.build(:order)
+    reward = FactoryBot.build(:reward, delivery_method: 'post')
+    order = FactoryBot.build(:order, reward: reward)
 
     EmployeeMailer.post_delivery_confirmation_email(order)
+  end
+
+  def pick_up_delivery_instructions_email
+    reward = FactoryBot.build(:reward, delivery_method: 'pick_up')
+    order = FactoryBot.build(:order, reward: reward)
+
+    EmployeeMailer.pick_up_delivery_instructions_email(order)
+  end
+
+  def pick_up_delivery_confirmation_email
+    reward = FactoryBot.build(:reward, delivery_method: 'pick_up')
+    order = FactoryBot.build(:order, reward: reward)
+
+    EmployeeMailer.pick_up_delivery_confirmation_email(order)
   end
 end

--- a/spec/services/create_order_service_spec.rb
+++ b/spec/services/create_order_service_spec.rb
@@ -89,4 +89,27 @@ RSpec.describe CreateOrderService do
       expect(service.errors.to_s).to include "City can't be blank"
     end
   end
+
+  context 'when buying a reward with pick-up delivery method' do
+    it 'returns true, adds new order to database when all params are properly set' do
+      employee = create(:employee, earned_points: 1)
+      reward_with_pick_up_delivery = create(:reward, delivery_method: 'pick_up')
+      order_params = { employee_id: employee.id, reward_id: reward_with_pick_up_delivery.id }
+      service = described_class.new(order_params)
+
+      result = nil
+      expect { result = service.call }.to change(Order, :count).by(1)
+      expect(result).to be true
+    end
+
+    it 'sends an email with instructions after purchase a reward with pick-up delivery' do
+      employee = create(:employee, earned_points: 1)
+      reward_with_pick_up_delivery = create(:reward, delivery_method: 'pick_up')
+      order_params = { employee_id: employee.id, reward_id: reward_with_pick_up_delivery.id }
+      service = described_class.new(order_params)
+
+      expect { service.call }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      expect(ActionMailer::Base.deliveries.last.subject).to eq 'Pick-up delivery instructions'
+    end
+  end
 end


### PR DESCRIPTION
Hey! The code which is below was implemented in order to meet the acceptance criterias of the third task in sprint no. 8 :)

AC in this task:
-- A reward should have a new delivery method: `pick-up`
-- When an employee chooses `pick-up` he should receive an email with pick-up instructions

I decided to add third delivery method for rewards. In my solutions employees cannot choose pick-up delivery method directly. They choose rewards whose have predetermined delivery method. That solution is a continuation of the position adopted in the seventh sprint. Acceptance criterias in that sprint were ambiguous and we had to decide if the method of reward delivery should be chosen by admin while creating a reward or by employee while purchasing a reward. I found a conversation in ask_project_manager channel on our Discord whose conclusion says about first option. So for consistency I took that position also in current task :)

Admin creates reward with one of three possible delivery methods and employees buy rewards with predetermined delivery method :)


https://user-images.githubusercontent.com/96024046/189207070-25c7c45d-2db2-4831-b26a-59753291aab4.mov

